### PR TITLE
Prevent text highlighting

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -100,7 +100,7 @@ h1 br {
   width: 99%;
 }
 
-.col-xs-5 {
+.prevent-select {
   -webkit-touch-callout: none;
   -webkit-user-select: none;
   -khtml-user-select: none;

--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@
         </ul>
       </div>
 
-      <div class="col-xs-5 scrollable" ng-controller="LabController as lc">
+      <div class="col-xs-5 scrollable prevent-select" ng-controller="LabController as lc">
         <input id="labname" value="{{ lc.lab.name }}" ng-model="lc.lab.name" ng-cloak>
         <hr>
         <button class="pull-right btn btn-info" ng-click="lc.showDetectorInfo()"><span class="glyphicon glyphicon-info-sign"></span></button>


### PR DESCRIPTION
Clicking on the detector would inadvertently highlight text

![screen shot 2014-08-07 at 1 37 33 pm](https://cloud.githubusercontent.com/assets/6556190/3848947/b29ad708-1e74-11e4-8ad8-58de419167d8.png)

Added css class that does nothing on user selection. Applied class to center div

![screen shot 2014-08-07 at 2 01 07 pm](https://cloud.githubusercontent.com/assets/6556190/3849121/0f855cbc-1e76-11e4-845f-c6f8fa4a3ff8.png)

![screen shot 2014-08-07 at 1 38 38 pm](https://cloud.githubusercontent.com/assets/6556190/3849137/27fc54d0-1e76-11e4-8652-f4e2228ebb4c.png)

Users can still click the info button to the top right of detector. This change only stops text on the center div from being selected.
