### PR TITLE
Set the number of events to delete correctly

### DIFF
--- a/js/detector.js
+++ b/js/detector.js
@@ -301,7 +301,7 @@ var detector =
             }
         }
 
-        if (del >= 0) {
+        if (del > 0) {
             detector.events.list.splice(0, del);
         }
     }


### PR DESCRIPTION
The code was only freeing up to 20 or so events, depending on how many particles the last non-visible event had.  Correctly setting the index to delete-up-to to be the highest non-visible event.
