### PR TITLE
No context menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <link rel="stylesheet" href="css/bootstrap.min.css">
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css">
     <link rel="stylesheet" href="css/style.css">
-    
+
     <link rel="icon" type="image/png" href="assets/favicon.png" />
     <link rel="apple-touch-icon" href="assets/mobile/icon.png">
     <link rel="apple-touch-icon" sizes="72x72" href="assets/mobile/icon.png">
@@ -28,7 +28,7 @@
     </script>
     <!-- End Google Analytics -->
   </head>
-  <body>  
+  <body oncontextmenu="return false;">
     <nav class="navbar navbar-default navbar-fixed-top" role="navigation">
       <div class="container-fluid">
         <div class="navbar-header">


### PR DESCRIPTION
Disable contextmenu so you don't accidentally click on the context menu when you're clicking the particle detector.