### PR TITLE
Fix lab name placeholder

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@
       </div>
 
       <div id="column-lab" class="col-xs-6 col-md-5 col-md-5s col-lg-6 col-no-padding-xs" ng-controller="LabController as lc">
-        <input class="hidden-xs" id="labname" value="{{ lc.lab.state.name }}" ng-model="lc.lab.state.name" ng-cloak>
+        <input class="hidden-xs" id="labname" placeholder="Give your lab an awesome name!" ng-model="lc.lab.state.name" ng-cloak>
         <hr class="hidden-xs">
         <div id="detector-holder">
           <div id="detector" ng-controller="DetectorController as dc">

--- a/js/gameobjects.js
+++ b/js/gameobjects.js
@@ -22,7 +22,7 @@ var GameObjects = (function() {
     GameObject.apply(this, [{
                              key : 'lab',
                              state : {
-                               name : 'Give your lab an awesome name!',
+                               name : '',
                                detector : 1,
                                factor : 5,
                                data : 0,


### PR DESCRIPTION
Thanks for the nice cookie-clicker!

Previously the placeholder was set as default value meaning one had to remove it before typing, annoying.

before:
<img width="711" alt="image" src="https://github.com/particle-clicker/particle-clicker/assets/56031107/e329c39d-c531-46b0-8beb-28dbd0ecd280">
after:
<img width="713" alt="image" src="https://github.com/particle-clicker/particle-clicker/assets/56031107/68c8034a-1bc7-491e-8385-71f08feb2f34">
